### PR TITLE
Add license + repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "ui5lab-library-simple",
   "version": "0.1.0",
   "description": "Sample of a custom UI5 library for the UI5Lab project",
+  "repository" : {
+      "type" : "git",
+      "url" : "https://github.com/UI5Lab/UI5Lab-library-simple.git"
+  },
+  "license" : "Apache-2.0",
   "private": false,
   "scripts": {
     "test": "echo \"Error: no test specified. Please add some.\" && exit 1",


### PR DESCRIPTION
This also helps to avoid the warnings after „npm install“. I’ve chosen
Apache 2 as license, feel free to change this.